### PR TITLE
Add instructions for deleting Watch directory if the install of the IPA fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This tweak makes Spotify think you have a Premium subscription, granting free li
 > 2. On your forked repository, go to **Repository Settings** > **Actions**, enable **Read and Write** permissions.
 
 <details>
-  <summary>How to build the EeveeSpotify IPA</summary>
+  <summary>How to build the EeveeSpotify IPA (click here)</summary>
   <ol>
     <li>Click on <strong>Sync fork</strong>, and if your branch is out-of-date, click on <strong>Update branch</strong>.</li>
     <li>Navigate to the <strong>Actions tab</strong> in your forked repository and select <strong>Create IPA Packages</strong> if you're on desktop/widescreen. Tap on <strong>All Workflows</strong> and select <strong>Create IPA Packages</strong> if you're on mobile/portrait.</li>
@@ -24,6 +24,7 @@ This tweak makes Spotify think you have a Premium subscription, granting free li
     <li>Go to the releases page of the EeveeSpotify repository (<strong>NOT</strong> the fork). Hold and copy the link of the .deb file, which corresponds to your phone's architecture.</li>
     <li>Make sure all inputs are correct, then click <strong>Run workflow</strong> to start the process.</li>
     <li>Wait for the build to finish. You can download the EeveeSpotify IPA from the releases section of your forked repo. (If you can't find the releases section, go to your forked repo and add /releases to the URL, i.e., github.com/user/EeveeSpotifyReborn/releases.)</li>
+    <li>If you have an issue while installing the IPA relating to the Watch app (WatchKit etc.) you will need to <strong>remove the Watch app from the IPA</strong>. Rename the file extension from <code>.ipa</code> to <code>.zip</code>, then unzip the file. The result should be a directory called <code>Payload</code>. Navigate inside and delete the <code>Watch</code> directory. Finally, recompress the <code>Payload</code> folder and change the extension to <code>.ipa</code>, and attempt to sideload the IPA again.</li>
   </ol>
 </details>
 


### PR DESCRIPTION
It may help users if they don't know how to fix this issue